### PR TITLE
fix: component would fail to load when using an instantsearch adapter

### DIFF
--- a/src/lib/InstantSearch.svelte
+++ b/src/lib/InstantSearch.svelte
@@ -36,7 +36,12 @@
 
     search.start();
 
-    searchClient.addAlgoliaAgent("svelte-algolia-instantsearch", "1.0.0");
+    // Try to add a custom user agent, but don't crash on fail since some instantsearch.js adapters don't have this.
+    try {
+        searchClient.addAlgoliaAgent("svelte-algolia-instantsearch", "1.0.0");
+    } catch (e) {
+        // ignore
+    }
 
     if (serverContext) {
       tick().then(() => {

--- a/src/lib/InstantSearch.svelte
+++ b/src/lib/InstantSearch.svelte
@@ -36,11 +36,8 @@
 
     search.start();
 
-    // Try to add a custom user agent, but don't crash on fail since some instantsearch.js adapters don't have this.
-    try {
-        searchClient.addAlgoliaAgent("svelte-algolia-instantsearch", "1.0.0");
-    } catch (e) {
-        // ignore
+    if('addAlgoliaAgent' in searchClient) {
+      searchClient.addAlgoliaAgent("svelte-algolia-instantsearch", "1.0.0");
     }
 
     if (serverContext) {


### PR DESCRIPTION
Using an adapter such as [Typesense](https://github.com/typesense/typesense-instantsearch-adapter), which doesn't have the `addAlgoliaAgent` function, could cause this component to not load.

Since this is just for the search user agent, it shouldn't be mission-critical if it fails to change the user agent string:
https://www.algolia.com/doc/api-client/getting-started/customize/javascript/?client=javascript#custom-user-agents