### PR TITLE
refactor: :recycle: add `input` as a supported class prop on `RefinementList`

### DIFF
--- a/src/lib/widgets/RefinementList.svelte
+++ b/src/lib/widgets/RefinementList.svelte
@@ -22,6 +22,10 @@
      */
     searchBox: string;
     /**
+     * Class names to apply to the input element
+     */
+    input: string;
+    /**
      * Class names to apply to the root element
      */
     noResults: string;
@@ -161,7 +165,7 @@
           }}
         >
           <input
-            class="ais-SearchBox-input"
+            class={cx("ais-SearchBox-input", classes.input)}
             type="search"
             bind:value={query}
             on:input={(event) => searchForItems(event.currentTarget.value)}


### PR DESCRIPTION
This allows styling the `<input>` element. Implementation copied from `SearchBox` component. Closes https://github.com/aymeric-giraudet/svelte-algolia-instantsearch/issues/24