### PR TITLE
refactor: :recycle: add `input` as a supported class prop on `RefinementList`

### DIFF
--- a/src/lib/widgets/RefinementList.svelte
+++ b/src/lib/widgets/RefinementList.svelte
@@ -26,6 +26,10 @@
      */
     input: string;
     /**
+     * Class names to apply to the reset button
+     */
+    reset: string;
+    /**
      * Class names to apply to the root element
      */
     noResults: string;
@@ -172,7 +176,7 @@
             placeholder={searchablePlaceholder}
           />
           <button
-            class="ais-SearchBox-reset"
+            class={cx("ais-SearchBox-reset", classes.reset)}
             on:click={() => {
               searchForItems("");
               query = "";


### PR DESCRIPTION
Similar to https://github.com/aymeric-giraudet/svelte-algolia-instantsearch/pull/25, this PR allows styling the `<button>` element on the `RefinementList` component. SearchBox has a class of the same name.

For example, default style vs customizable style:
![Screenshot from 2024-09-13 15-21-42](https://github.com/user-attachments/assets/aa318f31-3903-441b-ba12-2d40f7f70dd0)
![Screenshot from 2024-09-13 15-20-39](https://github.com/user-attachments/assets/3dcc948a-54e2-482e-870a-cbb65848bf1d)
